### PR TITLE
Fix cursor position to align with text

### DIFF
--- a/gui/TextInputElement.cpp
+++ b/gui/TextInputElement.cpp
@@ -63,8 +63,8 @@ void TextInputElement::render(Element* parent)
 	int w = letter_width, h = letter_height;
 
 	// draw the currently selected block
-	SDL_Rect cursor_pos = { textLocation.x + selected_x * w - 2, textLocation.y + selected_y * (h + 2) - 2,
-		selected_width * w + 4, selected_height * h + 4 };
+	SDL_Rect cursor_pos = { textLocation.x + selected_x * w - 2, textLocation.y + selected_y * h - 2,
+		selected_width * w + 4, selected_height * h + 2 };
 
 	if (insertMode) // TODO: use block cursor for overwrite mode too
 	{


### PR DESCRIPTION
There is a bug in cursor renderer that causes the cursor to be incorrectly aligned to multiline text. A change in cursor y and height calculation will fix the issue.

Before:
![2019081714455100-DB1426D1DFD034027CECDE9C2DD914B8](https://user-images.githubusercontent.com/15308471/63217581-8ad53c00-c0fd-11e9-8014-13a1a35d3d7b.jpg)

After:
![2019081713345200-DB1426D1DFD034027CECDE9C2DD914B8](https://user-images.githubusercontent.com/15308471/63217580-8a3ca580-c0fd-11e9-9360-85463b963d79.jpg)
