### PR TITLE
Set toolbar maximum file path length

### DIFF
--- a/gui/Toolbar.cpp
+++ b/gui/Toolbar.cpp
@@ -2,10 +2,16 @@
 
 Toolbar::Toolbar(const char* path)
 {
-	pathE = new TextElement(path, 20, 0, MONOSPACED);
+	if (strlen(path) > MAX_PATH_LENGTH) {
+		strcpy(this->path, "...");
+		strcpy(this->path + 3, path + strlen(path) - (MAX_PATH_LENGTH - 3));
+	} else {
+		strcpy(this->path, path);
+	}
+
+	pathE = new TextElement(this->path, 20, 0, MONOSPACED);
 	pathE->position(10, 10);
 	elements.push_back(pathE);
-	this->path = path;
 
 	SDL_Color white = { 0xFF, 0xFF, 0xFF, 0xFF };
 

--- a/gui/Toolbar.hpp
+++ b/gui/Toolbar.hpp
@@ -3,6 +3,8 @@
 class Toolbar : public Element
 {
 public:
+	const static int MAX_PATH_LENGTH = 48;
+
 	Toolbar(const char* path);
 	void setModified(bool modified);
 	void render(Element* parent);
@@ -11,7 +13,7 @@ public:
 	TextElement* actions = NULL;
 	TextElement* keyActions = NULL;
 
-	const char* path = NULL;
+	char path[MAX_PATH_LENGTH + 1];
 	bool modified = true;
 	bool keyboardShowing = false;
 };


### PR DESCRIPTION
There is a bug that causes long file paths to be displayed over the toolbar text, causing unreadability of both.

After the fix, the maximum file path length is set to 48. Any file path exceeding 48 characters will have its initial part be replaced by 3 dots.

![2019081714453300-DB1426D1DFD034027CECDE9C2DD914B8-copy](https://user-images.githubusercontent.com/15308471/63217618-236bbc00-c0fe-11e9-975d-99a5662fbf85.jpg)
